### PR TITLE
Added unit tests and fixed a bug in cell_new

### DIFF
--- a/Zigzag.pm
+++ b/Zigzag.pm
@@ -29,11 +29,11 @@
 # ===================== Change Log
 #
 # Inital Zigzag implementation
-# $Id: Zigzag.pm,v 0.71 2025/05/29 00:57:00 xanni Exp $
+# $Id: Zigzag.pm,v 0.71 2025/05/30 01:07:00 xanni Exp $
 #
 # $Log: Zigzag.pm,v $
-# Revision 0.71  2025/05/29 00:57:00  xanni
-# * Added unit tests and fixed bug in is_clone()
+# Revision 0.71  2025/05/30 01:07:00  xanni
+# * Added unit tests and fixed bugs in is_clone() and cell_new()
 #
 # Revision 0.70  1999/05/14 13:43:21  xanni
 # * Imported atcursor_edit from front end
@@ -1031,6 +1031,8 @@ sub cell_new(;$)
 
   # Assign contents of cell (defaults to the cell number)
   $Hash_Ref[0]{$new} = (defined $_[0]) ? $_[0] : $new;
+
+  return $new;
 }
 
 #

--- a/t/Zigzag.t
+++ b/t/Zigzag.t
@@ -12,39 +12,43 @@ BEGIN { use_ok('Zigzag'); }
 # and direct comparison with cell IDs.
 @Zigzag::Hash_Ref = ({}); 
 my $test_slice = $Zigzag::Hash_Ref[0];
-%{$test_slice} = Zigzag::initial_geometry(); # Load initial geometry
+# %{$test_slice} = Zigzag::initial_geometry(); # Load initial geometry
 
 subtest 'reverse_sign' => sub {
+    %$test_slice = Zigzag::initial_geometry(); # Initialize it
     plan tests => 2;
     is( Zigzag::reverse_sign('+d.1'), '-d.1', 'positive to negative');
     is( Zigzag::reverse_sign('-d.test'), '+d.test', 'negative to positive');
 };
 
-# --- Setup for is_cursor tests ---
-# These will overwrite/add to initial_geometry for specific test needs
-$test_slice->{'100'} = 'Cell 100 (cursor)';
-$test_slice->{'101'} = 'Cell 101 (target for cursor link)';
-$test_slice->{'102'} = 'Cell 102 (not a cursor)';
-$test_slice->{'100+d.cursor'} = '101'; $test_slice->{'101-d.cursor'} = '100';
-
 subtest 'is_cursor' => sub {
+    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+
+    # --- Setup for is_cursor tests (now using $test_slice) ---
+    $test_slice->{'100'} = 'Cell 100 (cursor)';
+    $test_slice->{'101'} = 'Cell 101 (target for cursor link)';
+    $test_slice->{'102'} = 'Cell 102 (not a cursor)';
+    $test_slice->{'100+d.cursor'} = '101'; $test_slice->{'101-d.cursor'} = '100';
+
     plan tests => 2;
     ok( Zigzag::is_cursor('100'), 'cell 100 is a cursor (returns 1)');
     ok( !Zigzag::is_cursor('102'), 'cell 102 is not a cursor (returns an empty string)');
 };
 
-# --- Setup for is_clone tests ---
-$test_slice->{'200'} = 'Cell 200 (clone via -d.clone)';
-$test_slice->{'299'} = 'Helper cell for 200-d.clone link'; 
-$test_slice->{'200-d.clone'} = '299'; $test_slice->{'299+d.clone'} = '200'; 
-
-$test_slice->{'201'} = 'Cell 201 (clone via +d.clone)';
-$test_slice->{'298'} = 'Helper cell for 201+d.clone link'; 
-$test_slice->{'201+d.clone'} = '298'; $test_slice->{'298-d.clone'} = '201';
-
-$test_slice->{'202'} = 'Cell 202 (not a clone)';
-
 subtest 'is_clone' => sub {
+    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+
+    # --- Setup for is_clone tests (now using $test_slice) ---
+    $test_slice->{'200'} = 'Cell 200 (clone via -d.clone)';
+    $test_slice->{'299'} = 'Helper cell for 200-d.clone link'; 
+    $test_slice->{'200-d.clone'} = '299'; $test_slice->{'299+d.clone'} = '200'; 
+
+    $test_slice->{'201'} = 'Cell 201 (clone via +d.clone)';
+    $test_slice->{'298'} = 'Helper cell for 201+d.clone link'; 
+    $test_slice->{'201+d.clone'} = '298'; $test_slice->{'298-d.clone'} = '201';
+
+    $test_slice->{'202'} = 'Cell 202 (not a clone)';
+
     plan tests => 3;
     ok( Zigzag::is_clone('200'), 'cell 200 is a clone (returns 1)');
     ok( Zigzag::is_clone('201'), 'cell 201 is a clone (via +d.clone)');
@@ -52,6 +56,7 @@ subtest 'is_clone' => sub {
 };
 
 subtest 'is_essential' => sub {
+    %$test_slice = Zigzag::initial_geometry(); # Initialize it
     plan tests => 5;
     # Essential cell IDs are 0, $CURSOR_HOME (10), $SELECT_HOME (21), $DELETE_HOME (99)
     # These tests rely on initial_geometry
@@ -62,75 +67,136 @@ subtest 'is_essential' => sub {
     ok( !Zigzag::is_essential('50'), 'cell 50 is not essential'); # Test with a non-essential number
 };
 
-# --- Setup for get_accursed tests ---
-# get_cursor(0) should return cell 11 (CURSOR_HOME +d.2 from initial_geometry)
-# We will make cell 111 the accursed cell for cursor 0 (cell 11)
-$test_slice->{'111'} = 'Cell 111 (accursed for cursor 0/cell 11)';
-$test_slice->{'11-d.cursor'} = '111'; $test_slice->{'111+d.cursor'} = '11';
-
 subtest 'get_accursed' => sub {
+    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+
+    # --- Setup for get_accursed tests (now using $test_slice) ---
+    # get_cursor(0) should return cell 11 (CURSOR_HOME +d.2 from initial_geometry)
+    # We will make cell 111 the accursed cell for cursor 0 (cell 11)
+    $test_slice->{'111'} = 'Cell 111 (accursed for cursor 0/cell 11)';
+    # Note: cell '11' is established by initial_geometry.
+    # We are modifying its '-d.cursor' link and creating the corresponding '+d.cursor' on '111'.
+    $test_slice->{'11-d.cursor'} = '111'; 
+    $test_slice->{'111+d.cursor'} = '11';
+
     plan tests => 1;
     is( Zigzag::get_accursed(0), '111', 'get_accursed(0): returns cell 111 (accursed for cursor 0/cell 11)');
 };
 
-# --- Setup for get_active_selection and get_selection tests ---
-my $SELECT_HOME = 21; # From Zigzag.pm constants (already in initial_geometry)
-
-# Define new cells for selections
-$test_slice->{'22'}  = 'Selection Head 1'; 
-$test_slice->{'400'} = 'Cell 400 for active selection';
-$test_slice->{'401'} = 'Cell 401 for active selection';
-$test_slice->{'402'} = 'Cell 402 for secondary selection';
-
-# Active selection (selection 0, around $SELECT_HOME)
-$test_slice->{"${SELECT_HOME}+d.mark"} = '400'; $test_slice->{'400-d.mark'} = $SELECT_HOME;
-$test_slice->{'400+d.mark'} = '401';           $test_slice->{'401-d.mark'} = '400';
-$test_slice->{'401+d.mark'} = $SELECT_HOME;    $test_slice->{"${SELECT_HOME}-d.mark"} = '401'; # Cycle complete
-
-# Secondary selection (selection 1, head cell 22)
-# Link new selection head 22 into the list of selections (21 <-> 22)
-$test_slice->{"${SELECT_HOME}+d.2"} = '22';    $test_slice->{'22-d.2'} = $SELECT_HOME;
-$test_slice->{'22+d.2'} = $SELECT_HOME;       # Cycle selection heads (21 is already -d.2 from 22 via initial_geometry if not overwritten)
-$test_slice->{"${SELECT_HOME}-d.2"} = '22';   # Explicitly make 21 point back to 22 in -d.2
-
-# Link cells to selection head 22
-$test_slice->{'22+d.mark'} = '402';            $test_slice->{'402-d.mark'} = '22';
-$test_slice->{'402+d.mark'} = '22';            $test_slice->{'22-d.mark'} = '402'; # Cycle complete
-
 subtest 'get_active_selection' => sub {
+    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+
+    # --- Setup for get_active_selection, get_selection, get_which_selection (using $test_slice) ---
+    my $SELECT_HOME = 21; # From Zigzag.pm constants (already in initial_geometry)
+
+    # Define new cells for selections
+    $test_slice->{'22'}  = 'Selection Head 1'; 
+    $test_slice->{'400'} = 'Cell 400 for active selection';
+    $test_slice->{'401'} = 'Cell 401 for active selection';
+    $test_slice->{'402'} = 'Cell 402 for secondary selection';
+
+    # Active selection (selection 0, around $SELECT_HOME)
+    $test_slice->{"${SELECT_HOME}+d.mark"} = '400'; $test_slice->{'400-d.mark'} = $SELECT_HOME;
+    $test_slice->{'400+d.mark'} = '401';           $test_slice->{'401-d.mark'} = '400';
+    $test_slice->{'401+d.mark'} = $SELECT_HOME;    $test_slice->{"${SELECT_HOME}-d.mark"} = '401'; # Cycle complete
+
+    # Secondary selection (selection 1, head cell 22)
+    # Link new selection head 22 into the list of selections (21 <-> 22)
+    $test_slice->{"${SELECT_HOME}+d.2"} = '22';    $test_slice->{'22-d.2'} = $SELECT_HOME;
+    $test_slice->{'22+d.2'} = $SELECT_HOME;       # Cycle selection heads (21 is already -d.2 from 22 via initial_geometry if not overwritten)
+    $test_slice->{"${SELECT_HOME}-d.2"} = '22';   # Explicitly make 21 point back to 22 in -d.2
+
+    # Link cells to selection head 22
+    $test_slice->{'22+d.mark'} = '402';            $test_slice->{'402-d.mark'} = '22';
+    $test_slice->{'402+d.mark'} = '22';            $test_slice->{'22-d.mark'} = '402'; # Cycle complete
+
     plan tests => 1;
     is_deeply( [Zigzag::get_active_selection()], ['400', '401', $SELECT_HOME], 'returns cells 400, 401, and 21');
 };
 
 subtest 'get_selection' => sub {
+    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+
+    # --- Setup for get_active_selection, get_selection, get_which_selection (using $test_slice) ---
+    my $SELECT_HOME = 21; # From Zigzag.pm constants (already in initial_geometry)
+
+    # Define new cells for selections
+    $test_slice->{'22'}  = 'Selection Head 1'; 
+    $test_slice->{'400'} = 'Cell 400 for active selection';
+    $test_slice->{'401'} = 'Cell 401 for active selection';
+    $test_slice->{'402'} = 'Cell 402 for secondary selection';
+
+    # Active selection (selection 0, around $SELECT_HOME)
+    $test_slice->{"${SELECT_HOME}+d.mark"} = '400'; $test_slice->{'400-d.mark'} = $SELECT_HOME;
+    $test_slice->{'400+d.mark'} = '401';           $test_slice->{'401-d.mark'} = '400';
+    $test_slice->{'401+d.mark'} = $SELECT_HOME;    $test_slice->{"${SELECT_HOME}-d.mark"} = '401'; # Cycle complete
+
+    # Secondary selection (selection 1, head cell 22)
+    # Link new selection head 22 into the list of selections (21 <-> 22)
+    $test_slice->{"${SELECT_HOME}+d.2"} = '22';    $test_slice->{'22-d.2'} = $SELECT_HOME;
+    $test_slice->{'22+d.2'} = $SELECT_HOME;       # Cycle selection heads (21 is already -d.2 from 22 via initial_geometry if not overwritten)
+    $test_slice->{"${SELECT_HOME}-d.2"} = '22';   # Explicitly make 21 point back to 22 in -d.2
+
+    # Link cells to selection head 22
+    $test_slice->{'22+d.mark'} = '402';            $test_slice->{'402-d.mark'} = '22';
+    $test_slice->{'402+d.mark'} = '22';            $test_slice->{'22-d.mark'} = '402'; # Cycle complete
+
     plan tests => 1;
     is_deeply( [Zigzag::get_selection(1)], ['402', '22'], 'get_selection(1): returns cells 402 and 22');
 };
 
 subtest 'get_which_selection' => sub {
+    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+
+    # --- Setup for get_active_selection, get_selection, get_which_selection (using $test_slice) ---
+    my $SELECT_HOME = 21; # From Zigzag.pm constants (already in initial_geometry)
+
+    # Define new cells for selections
+    $test_slice->{'22'}  = 'Selection Head 1'; 
+    $test_slice->{'400'} = 'Cell 400 for active selection';
+    $test_slice->{'401'} = 'Cell 401 for active selection';
+    $test_slice->{'402'} = 'Cell 402 for secondary selection';
+
+    # Active selection (selection 0, around $SELECT_HOME)
+    $test_slice->{"${SELECT_HOME}+d.mark"} = '400'; $test_slice->{'400-d.mark'} = $SELECT_HOME;
+    $test_slice->{'400+d.mark'} = '401';           $test_slice->{'401-d.mark'} = '400';
+    $test_slice->{'401+d.mark'} = $SELECT_HOME;    $test_slice->{"${SELECT_HOME}-d.mark"} = '401'; # Cycle complete
+
+    # Secondary selection (selection 1, head cell 22)
+    # Link new selection head 22 into the list of selections (21 <-> 22)
+    $test_slice->{"${SELECT_HOME}+d.2"} = '22';    $test_slice->{'22-d.2'} = $SELECT_HOME;
+    $test_slice->{'22+d.2'} = $SELECT_HOME;       # Cycle selection heads (21 is already -d.2 from 22 via initial_geometry if not overwritten)
+    $test_slice->{"${SELECT_HOME}-d.2"} = '22';   # Explicitly make 21 point back to 22 in -d.2
+
+    # Link cells to selection head 22
+    $test_slice->{'22+d.mark'} = '402';            $test_slice->{'402-d.mark'} = '22';
+    $test_slice->{'402+d.mark'} = '22';            $test_slice->{'22-d.mark'} = '402'; # Cycle complete
+
     plan tests => 3;
     is( Zigzag::get_which_selection('400'), '401', 'cell in active selection returns 401');
     is( Zigzag::get_which_selection('402'), '22', 'cell in secondary selection returns 22');
     is( Zigzag::get_which_selection('102'), undef, 'cell not in selection returns undef');
 };
 
-# --- Setup for get_lastcell tests ---
-# Linear chain: 500 <-> 501 <-> 502 in d.testchain
-$test_slice->{'500'} = 'Cell 500 (start of linear chain)';
-$test_slice->{'501'} = 'Cell 501 (middle of linear chain)';
-$test_slice->{'502'} = 'Cell 502 (end of linear chain)';
-$test_slice->{'500+d.testchain'} = '501'; $test_slice->{'501-d.testchain'} = '500';
-$test_slice->{'501+d.testchain'} = '502'; $test_slice->{'502-d.testchain'} = '501';
-
-# Circular list: 600 <-> 601 <-> 602 <-> 600 in d.testcircle
-$test_slice->{'600'} = 'Cell 600 (part of circular list)';
-$test_slice->{'601'} = 'Cell 601 (part of circular list)';
-$test_slice->{'602'} = 'Cell 602 (part of circular list)';
-$test_slice->{'600+d.testcircle'} = '601'; $test_slice->{'601-d.testcircle'} = '600';
-$test_slice->{'601+d.testcircle'} = '602'; $test_slice->{'602-d.testcircle'} = '601';
-$test_slice->{'602+d.testcircle'} = '600'; $test_slice->{'600-d.testcircle'} = '602';
-
 subtest 'get_lastcell' => sub {
+    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+
+    # --- Setup for get_lastcell tests (now using $test_slice) ---
+    # Linear chain: 500 <-> 501 <-> 502 in d.testchain
+    $test_slice->{'500'} = 'Cell 500 (start of linear chain)';
+    $test_slice->{'501'} = 'Cell 501 (middle of linear chain)';
+    $test_slice->{'502'} = 'Cell 502 (end of linear chain)';
+    $test_slice->{'500+d.testchain'} = '501'; $test_slice->{'501-d.testchain'} = '500';
+    $test_slice->{'501+d.testchain'} = '502'; $test_slice->{'502-d.testchain'} = '501';
+
+    # Circular list: 600 <-> 601 <-> 602 <-> 600 in d.testcircle
+    $test_slice->{'600'} = 'Cell 600 (part of circular list)';
+    $test_slice->{'601'} = 'Cell 601 (part of circular list)';
+    $test_slice->{'602'} = 'Cell 602 (part of circular list)';
+    $test_slice->{'600+d.testcircle'} = '601'; $test_slice->{'601-d.testcircle'} = '600';
+    $test_slice->{'601+d.testcircle'} = '602'; $test_slice->{'602-d.testcircle'} = '601';
+    $test_slice->{'602+d.testcircle'} = '600'; $test_slice->{'600-d.testcircle'} = '602';
+
     plan tests => 4;
     # Linear chain tests
     is( Zigzag::get_lastcell('500', '+d.testchain'), '502', '(linear +): start 500, end 502');
@@ -140,16 +206,18 @@ subtest 'get_lastcell' => sub {
     is( Zigzag::get_lastcell('600', '-d.testcircle'), '601', '(circular -): start 600, returns cell before start (601)');
 };
 
-# --- Setup for get_distance tests ---
-$test_slice->{'700'} = 'Cell 700 for get_distance';
-$test_slice->{'701'} = 'Cell 701 for get_distance';
-$test_slice->{'702'} = 'Cell 702 for get_distance';
-$test_slice->{'705'} = 'Cell 705 for get_distance (isolated)';
-# Chain: 700 <-> 701 <-> 702 in +d.testdist
-$test_slice->{'700+d.testdist'} = '701'; $test_slice->{'701-d.testdist'} = '700';
-$test_slice->{'701+d.testdist'} = '702'; $test_slice->{'702-d.testdist'} = '701';
-
 subtest 'get_distance' => sub {
+    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+
+    # --- Setup for get_distance tests (now using $test_slice) ---
+    $test_slice->{'700'} = 'Cell 700 for get_distance';
+    $test_slice->{'701'} = 'Cell 701 for get_distance';
+    $test_slice->{'702'} = 'Cell 702 for get_distance';
+    $test_slice->{'705'} = 'Cell 705 for get_distance (isolated)';
+    # Chain: 700 <-> 701 <-> 702 in +d.testdist
+    $test_slice->{'700+d.testdist'} = '701'; $test_slice->{'701-d.testdist'} = '700';
+    $test_slice->{'701+d.testdist'} = '702'; $test_slice->{'702-d.testdist'} = '701';
+
     plan tests => 7;
     is( Zigzag::get_distance('700', '+d.testdist', '702'), 2, "('700', '+d.testdist', '702') is 2");
     is( Zigzag::get_distance('702', '-d.testdist', '700'), 2, "('702', '-d.testdist', '700') is 2");
@@ -160,45 +228,49 @@ subtest 'get_distance' => sub {
     is( Zigzag::get_distance('700', '+d.otherdim', '701'), undef, "('700', '+d.otherdim', '701') is undef (wrong dimension)");
 };
 
-# --- Setup for get_outline_parent tests ---
-$test_slice->{'800'} = 'Cell 800 (child for outline parent)';
-$test_slice->{'801'} = 'Cell 801 (parent for outline parent)';
-$test_slice->{'802'} = 'Cell 802 (intermediate for 800-d.2)';
-$test_slice->{'803'} = 'Cell 803 (unrelated for outline parent)'; # Not used by links, just defined
-
-# Case 1: 800 has parent 801 via 802
-$test_slice->{'800-d.2'} = '802'; $test_slice->{'802+d.2'} = '800';
-$test_slice->{'802-d.1'} = '801'; $test_slice->{'801+d.1'} = '802';
-
-# Case 2: 801 is its own "outline parent" (no -d.2 path to another -d.1)
-$test_slice->{'801-d.2'} = '801'; $test_slice->{'801+d.2'} = '801'; # Loop on itself in -d.2
-
-# Case 3: 810 has no outline parent (circular -d.2 chain without -d.1)
-$test_slice->{'810'} = 'Cell 810 (no outline parent)';
-$test_slice->{'811'} = 'Cell 811 (part of 810s -d.2 loop)';
-$test_slice->{'810-d.2'} = '811'; $test_slice->{'811+d.2'} = '810';
-$test_slice->{'811-d.2'} = '810'; $test_slice->{'810+d.2'} = '811';
-
 subtest 'get_outline_parent' => sub {
+    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+
+    # --- Setup for get_outline_parent tests (now using $test_slice) ---
+    $test_slice->{'800'} = 'Cell 800 (child for outline parent)';
+    $test_slice->{'801'} = 'Cell 801 (parent for outline parent)';
+    $test_slice->{'802'} = 'Cell 802 (intermediate for 800-d.2)';
+    $test_slice->{'803'} = 'Cell 803 (unrelated for outline parent)'; # Not used by links, just defined
+
+    # Case 1: 800 has parent 801 via 802
+    $test_slice->{'800-d.2'} = '802'; $test_slice->{'802+d.2'} = '800';
+    $test_slice->{'802-d.1'} = '801'; $test_slice->{'801+d.1'} = '802';
+
+    # Case 2: 801 is its own "outline parent" (no -d.2 path to another -d.1)
+    $test_slice->{'801-d.2'} = '801'; $test_slice->{'801+d.2'} = '801'; # Loop on itself in -d.2
+
+    # Case 3: 810 has no outline parent (circular -d.2 chain without -d.1)
+    $test_slice->{'810'} = 'Cell 810 (no outline parent)';
+    $test_slice->{'811'} = 'Cell 811 (part of 810s -d.2 loop)';
+    $test_slice->{'810-d.2'} = '811'; $test_slice->{'811+d.2'} = '810';
+    $test_slice->{'811-d.2'} = '810'; $test_slice->{'810+d.2'} = '811';
+
     plan tests => 3;
     is( Zigzag::get_outline_parent('800'), '801', "('800') is '801'");
     is( Zigzag::get_outline_parent('801'), '801', "('801') (parent itself, -d.2 loops) is '801'");
     is( Zigzag::get_outline_parent('810'), '811', "('810') (circular -d.2, stops at 811) is '811'");
 };
 
-# --- Setup for get_cell_contents tests ---
-$test_slice->{'850'} = 'Direct content for 850';
-$test_slice->{'851'} = 'Cell 851 (clone of 852)'; # This content is just a note
-$test_slice->{'852'} = 'Content from original cell 852';
-$test_slice->{'851-d.clone'} = '852'; $test_slice->{'852+d.clone'} = '851';
-
-$test_slice->{'853'} = 'Cell 853 (clone of 854)'; # This content is just a note
-$test_slice->{'854'} = 'Content from original cell 854';
-$test_slice->{'853+d.clone'} = '854'; $test_slice->{'854-d.clone'} = '853';
-
-$test_slice->{'855'} = '[10+20]'; # Special ZZMail-like content
-
 subtest 'get_cell_contents' => sub {
+    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+
+    # --- Setup for get_cell_contents tests (now using $test_slice) ---
+    $test_slice->{'850'} = 'Direct content for 850';
+    $test_slice->{'851'} = 'Cell 851 (clone of 852)'; # This content is just a note
+    $test_slice->{'852'} = 'Content from original cell 852';
+    $test_slice->{'851-d.clone'} = '852'; $test_slice->{'852+d.clone'} = '851';
+
+    $test_slice->{'853'} = 'Cell 853 (clone of 854)'; # This content is just a note
+    $test_slice->{'854'} = 'Content from original cell 854';
+    $test_slice->{'853+d.clone'} = '854'; $test_slice->{'854-d.clone'} = '853';
+
+    $test_slice->{'855'} = '[10+20]'; # Special ZZMail-like content
+
     plan tests => 4;
     is( Zigzag::get_cell_contents('850'), 'Direct content for 850', "('850') returns direct content");
     is( Zigzag::get_cell_contents('851'), 'Content from original cell 852', "('851') returns content of original (-d.clone)");
@@ -206,15 +278,17 @@ subtest 'get_cell_contents' => sub {
     is( Zigzag::get_cell_contents('855'), '[10+20]', "('855') returns raw ZZMail-like content when ZZMAIL_SUPPORT is false");
 };
 
-# --- Setup for get_cursor tests ---
-# initial_geometry provides cursor 0 (11) and cursor 1 (16)
-# $CURSOR_HOME (10) -> 11 (cursor 0) -> 16 (cursor 1)
-$test_slice->{'900'} = 'Test Cursor 2';
-$test_slice->{'16+d.2'} = '900'; # Link from cursor 1 (cell 16) to cursor 2 (cell 900)
-$test_slice->{'900-d.2'} = '16'; # Bidirectional link
-# Cell 900 has no '+d.2' link, marking the end of the explicit cursor chain for testing die condition
-
 subtest 'get_cursor' => sub {
+    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+
+    # --- Setup for get_cursor tests (now using $test_slice) ---
+    # initial_geometry provides cursor 0 (11) and cursor 1 (16)
+    # $CURSOR_HOME (10) -> 11 (cursor 0) -> 16 (cursor 1)
+    $test_slice->{'900'} = 'Test Cursor 2';
+    $test_slice->{'16+d.2'} = '900'; # Link from cursor 1 (cell 16) to cursor 2 (cell 900)
+    $test_slice->{'900-d.2'} = '16'; # Bidirectional link
+    # Cell 900 has no '+d.2' link, marking the end of the explicit cursor chain for testing die condition
+
     plan tests => 4;
     is( Zigzag::get_cursor(0), '11', "(0) returns cell 11 (from initial_geometry)");
     is( Zigzag::get_cursor(1), '16', "(1) returns cell 16 (from initial_geometry)");
@@ -227,6 +301,7 @@ subtest 'get_cursor' => sub {
 };
 
 subtest 'get_dimension' => sub {
+    %$test_slice = Zigzag::initial_geometry(); # Initialize it
     plan tests => 7;
     my $cursor_cell_for_dim_test = Zigzag::get_cursor(0); # Should be 11
     # Expected dimensions based on initial_geometry for cursor 0 (cell 11):
@@ -246,18 +321,20 @@ subtest 'get_dimension' => sub {
     like($@, qr/\Q$expected_error_msg_dim\E/, "with invalid direction $invalid_dir dies with message '$expected_error_msg_dim'");
 };
 
-# --- Setup for get_links_to tests ---
-# Define target and source cells
-$test_slice->{'950'} = 'Target cell for links';
-$test_slice->{'951'} = 'Source cell 1';
-$test_slice->{'952'} = 'Source cell 2';
-$test_slice->{'953'} = 'Source cell 3';
-$test_slice->{'960'} = 'Cell with no links';
-$test_slice->{'951+d.1'} = '950'; $test_slice->{'950-d.1'} = '951';
-$test_slice->{'952+d.2'} = '950'; $test_slice->{'950-d.2'} = '952';
-$test_slice->{'953+d.clone'} = '950'; $test_slice->{'950-d.clone'} = '953';
-
 subtest 'get_links_to' => sub {
+    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+
+    # --- Setup for get_links_to tests (now using $test_slice) ---
+    # Define target and source cells
+    $test_slice->{'950'} = 'Target cell for links';
+    $test_slice->{'951'} = 'Source cell 1';
+    $test_slice->{'952'} = 'Source cell 2';
+    $test_slice->{'953'} = 'Source cell 3';
+    $test_slice->{'960'} = 'Cell with no links';
+    $test_slice->{'951+d.1'} = '950'; $test_slice->{'950-d.1'} = '951';
+    $test_slice->{'952+d.2'} = '950'; $test_slice->{'950-d.2'} = '952';
+    $test_slice->{'953+d.clone'} = '950'; $test_slice->{'950-d.clone'} = '953';
+
     plan tests => 4;
     my @links_to_950 = sort(Zigzag::get_links_to('950'));
     is(scalar @links_to_950, 3, '(950): returns 3 links (using standard dimensions)');
@@ -269,6 +346,7 @@ subtest 'get_links_to' => sub {
 };
 
 subtest 'wordbreak' => sub {
+    %$test_slice = Zigzag::initial_geometry(); # Initialize it
     plan tests => 4;
     is( Zigzag::wordbreak("short string", 20), "short string", "string shorter than limit");
     is( Zigzag::wordbreak("long string with spaces", 10), "long", "breaks at space before limit");
@@ -277,6 +355,7 @@ subtest 'wordbreak' => sub {
 };
 
 subtest 'dimension_is_essential' => sub {
+    %$test_slice = Zigzag::initial_geometry(); # Initialize it
     plan tests => 10;
     ok( Zigzag::dimension_is_essential('d.1'), "d.1 is essential");
     ok( Zigzag::dimension_is_essential('+d.2'), "+d.2 is essential");
@@ -292,9 +371,8 @@ subtest 'dimension_is_essential' => sub {
 
 # --- Tests for cell_new ---
 subtest 'cell_new' => sub {
+    %$test_slice = Zigzag::initial_geometry(); # Initialize it
     plan tests => 14;
-
-    my $initial_n = $Zigzag::Hash_Ref[0]{"n"}; # Store initial "n"
 
     # Test Case 1: Create a new cell with default content.
     my $new_cell_id_default = Zigzag::cell_new();
@@ -309,15 +387,14 @@ subtest 'cell_new' => sub {
     is($test_slice->{$new_cell_id_content}, $custom_content, "2.2: New cell ($new_cell_id_content) has specified content");
 
     # Test Case 3: Create multiple new cells to ensure unique IDs.
-    # Assuming $new_cell_id_default and $new_cell_id_content were taken from 'n'
-    # $Zigzag::Hash_Ref[0]{"n"} should be $initial_n + 2 at this point.
-    my $next_id_before_multi = $Zigzag::Hash_Ref[0]{"n"};
+    # 'n' is initialized by initial_geometry() and managed by cell_new()
+    my $next_id_before_multi = $test_slice->{"n"};
     my $cell_id1_multi = Zigzag::cell_new();
     my $cell_id2_multi = Zigzag::cell_new();
     isnt($cell_id1_multi, $cell_id2_multi, "3.1: Multiple new cell IDs ($cell_id1_multi, $cell_id2_multi) are different");
     is($cell_id1_multi, $next_id_before_multi, "3.2: First new cell ID ($cell_id1_multi) is as expected ($next_id_before_multi)");
     is($cell_id2_multi, $next_id_before_multi + 1, "3.3: Second new cell ID ($cell_id2_multi) is incremented from first");
-    is($Zigzag::Hash_Ref[0]{"n"}, $next_id_before_multi + 2, "3.4: Global 'n' is updated correctly after multiple creations");
+    is($test_slice->{"n"}, $next_id_before_multi + 2, "3.4: Global 'n' is updated correctly after multiple creations");
 
     # Test Case 4: Recycle a cell.
     my $DELETE_HOME = 99; # Defined in Zigzag.pm
@@ -355,18 +432,12 @@ subtest 'cell_new' => sub {
     # We can delete it or leave it with its new content for this test scope.
     # For strictness, delete it if no other test expects it.
     delete $test_slice->{$recyclable_cell_id};
-    # Restore 'n' to what it was before this subtest to avoid impacting subsequent tests
-    # that might rely on 'n' starting from where initial_geometry left it.
-    # This is tricky because other tests might also call cell_new.
-    # For now, we assume 'n' is managed globally and tests should accommodate its increase.
-    # The most robust way would be to calculate how many new cells this test *actually* created from 'n'
-    # (default, content, multi1, multi2 = 4 cells from 'n') and decrement 'n' by that.
-    # The recycle test reuses a cell, so it doesn't increment 'n'.
-    $Zigzag::Hash_Ref[0]{"n"} = $initial_n + 4; # Correctly reflect cells taken from 'n'
+    # Note: 'n' is no longer manually restored. Each subtest gets a fresh 'n' via initial_geometry().
 };
 
 # --- Tests for cell_excise ---
 subtest 'cell_excise' => sub {
+    %$test_slice = Zigzag::initial_geometry(); # Initialize it
     plan tests => 17;
 
     my $dim = 'd.testex'; # Common dimension for most tests
@@ -434,15 +505,11 @@ subtest 'cell_excise' => sub {
     my $non_existent_cell = 'nonexistent_cell_excise';
     eval { Zigzag::cell_excise($non_existent_cell, $dim); };
     like($@, qr/No cell $non_existent_cell/, "6.1: Die when cell does not exist");
-
-    # General cleanup of defined cells for this subtest
-    delete $test_slice->{$cell_A}; delete $test_slice->{$cell_B}; delete $test_slice->{$cell_C};
-    delete $test_slice->{$cell_S};
-    delete $test_slice->{$cell_circA}; delete $test_slice->{$cell_circB};
 };
 
 # --- Setup for link_make tests ---
 subtest 'link_make' => sub {
+    %$test_slice = Zigzag::initial_geometry(); # Initialize it
     plan tests => 7; # 2 for success, 5 for die cases
 
     # Test 1: Successful link
@@ -487,17 +554,11 @@ subtest 'link_make' => sub {
     # Now 1003 is linked from 1002 via -d.testlink_t6 (1003-d.testlink_t6 = 1002)
     eval { Zigzag::link_make('1004', '1003', '+d.testlink_t6'); }; # A to B with +D
     like($@, qr/1003 already linked/, "link_make: die when cell2 already linked in reverse_sign(dir)");
-
-    # Cleanup for next tests
-    delete $test_slice->{'1000'}; delete $test_slice->{'1001'}; delete $test_slice->{'1002'}; delete $test_slice->{'1003'};
-    delete $test_slice->{'1004'};
-    # delete $test_slice->{'1005'}; delete $test_slice->{'1006'}; # These were from old test 6
-    delete $test_slice->{'1002+d.testlink_t6'}; delete $test_slice->{'1003-d.testlink_t6'};
-    # delete $test_slice->{'1006-d.testlink2'}; delete $test_slice->{'1005+d.testlink2'}; # From old test 6
 };
 
 # --- Setup for link_break tests ---
 subtest 'link_break' => sub {
+    %$test_slice = Zigzag::initial_geometry(); # Initialize it
     plan tests => 12; # 2x2 for success cases, 8 for die cases
 
     # Setup cells for link_break tests

--- a/t/Zigzag.t
+++ b/t/Zigzag.t
@@ -7,24 +7,18 @@ use Test::More tests => 22;
 BEGIN { use_ok('Zigzag'); }
 
 # Setup data for all tests in slice 0
-# Note: is_essential tests do not require data setup in @Zigzag::Hash_Ref
-# as they rely on constants defined in Zigzag.pm (CURSOR_HOME, etc.)
-# and direct comparison with cell IDs.
 @Zigzag::Hash_Ref = ({}); 
 my $test_slice = $Zigzag::Hash_Ref[0];
-# %{$test_slice} = Zigzag::initial_geometry(); # Load initial geometry
 
 subtest 'reverse_sign' => sub {
-    %$test_slice = Zigzag::initial_geometry(); # Initialize it
     plan tests => 2;
     is( Zigzag::reverse_sign('+d.1'), '-d.1', 'positive to negative');
     is( Zigzag::reverse_sign('-d.test'), '+d.test', 'negative to positive');
 };
 
 subtest 'is_cursor' => sub {
-    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+    %$test_slice = Zigzag::initial_geometry();
 
-    # --- Setup for is_cursor tests (now using $test_slice) ---
     $test_slice->{'100'} = 'Cell 100 (cursor)';
     $test_slice->{'101'} = 'Cell 101 (target for cursor link)';
     $test_slice->{'102'} = 'Cell 102 (not a cursor)';
@@ -36,9 +30,8 @@ subtest 'is_cursor' => sub {
 };
 
 subtest 'is_clone' => sub {
-    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+    %$test_slice = Zigzag::initial_geometry();
 
-    # --- Setup for is_clone tests (now using $test_slice) ---
     $test_slice->{'200'} = 'Cell 200 (clone via -d.clone)';
     $test_slice->{'299'} = 'Helper cell for 200-d.clone link'; 
     $test_slice->{'200-d.clone'} = '299'; $test_slice->{'299+d.clone'} = '200'; 
@@ -56,7 +49,8 @@ subtest 'is_clone' => sub {
 };
 
 subtest 'is_essential' => sub {
-    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+    %$test_slice = Zigzag::initial_geometry();
+
     plan tests => 5;
     # Essential cell IDs are 0, $CURSOR_HOME (10), $SELECT_HOME (21), $DELETE_HOME (99)
     # These tests rely on initial_geometry
@@ -68,9 +62,8 @@ subtest 'is_essential' => sub {
 };
 
 subtest 'get_accursed' => sub {
-    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+    %$test_slice = Zigzag::initial_geometry();
 
-    # --- Setup for get_accursed tests (now using $test_slice) ---
     # get_cursor(0) should return cell 11 (CURSOR_HOME +d.2 from initial_geometry)
     # We will make cell 111 the accursed cell for cursor 0 (cell 11)
     $test_slice->{'111'} = 'Cell 111 (accursed for cursor 0/cell 11)';
@@ -84,52 +77,32 @@ subtest 'get_accursed' => sub {
 };
 
 subtest 'get_active_selection' => sub {
-    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+    %$test_slice = Zigzag::initial_geometry();
 
-    # --- Setup for get_active_selection, get_selection, get_which_selection (using $test_slice) ---
     my $SELECT_HOME = 21; # From Zigzag.pm constants (already in initial_geometry)
 
     # Define new cells for selections
     $test_slice->{'22'}  = 'Selection Head 1'; 
     $test_slice->{'400'} = 'Cell 400 for active selection';
     $test_slice->{'401'} = 'Cell 401 for active selection';
-    $test_slice->{'402'} = 'Cell 402 for secondary selection';
 
     # Active selection (selection 0, around $SELECT_HOME)
     $test_slice->{"${SELECT_HOME}+d.mark"} = '400'; $test_slice->{'400-d.mark'} = $SELECT_HOME;
     $test_slice->{'400+d.mark'} = '401';           $test_slice->{'401-d.mark'} = '400';
     $test_slice->{'401+d.mark'} = $SELECT_HOME;    $test_slice->{"${SELECT_HOME}-d.mark"} = '401'; # Cycle complete
-
-    # Secondary selection (selection 1, head cell 22)
-    # Link new selection head 22 into the list of selections (21 <-> 22)
-    $test_slice->{"${SELECT_HOME}+d.2"} = '22';    $test_slice->{'22-d.2'} = $SELECT_HOME;
-    $test_slice->{'22+d.2'} = $SELECT_HOME;       # Cycle selection heads (21 is already -d.2 from 22 via initial_geometry if not overwritten)
-    $test_slice->{"${SELECT_HOME}-d.2"} = '22';   # Explicitly make 21 point back to 22 in -d.2
-
-    # Link cells to selection head 22
-    $test_slice->{'22+d.mark'} = '402';            $test_slice->{'402-d.mark'} = '22';
-    $test_slice->{'402+d.mark'} = '22';            $test_slice->{'22-d.mark'} = '402'; # Cycle complete
 
     plan tests => 1;
     is_deeply( [Zigzag::get_active_selection()], ['400', '401', $SELECT_HOME], 'returns cells 400, 401, and 21');
 };
 
 subtest 'get_selection' => sub {
-    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+    %$test_slice = Zigzag::initial_geometry();
 
-    # --- Setup for get_active_selection, get_selection, get_which_selection (using $test_slice) ---
     my $SELECT_HOME = 21; # From Zigzag.pm constants (already in initial_geometry)
 
     # Define new cells for selections
     $test_slice->{'22'}  = 'Selection Head 1'; 
-    $test_slice->{'400'} = 'Cell 400 for active selection';
-    $test_slice->{'401'} = 'Cell 401 for active selection';
     $test_slice->{'402'} = 'Cell 402 for secondary selection';
-
-    # Active selection (selection 0, around $SELECT_HOME)
-    $test_slice->{"${SELECT_HOME}+d.mark"} = '400'; $test_slice->{'400-d.mark'} = $SELECT_HOME;
-    $test_slice->{'400+d.mark'} = '401';           $test_slice->{'401-d.mark'} = '400';
-    $test_slice->{'401+d.mark'} = $SELECT_HOME;    $test_slice->{"${SELECT_HOME}-d.mark"} = '401'; # Cycle complete
 
     # Secondary selection (selection 1, head cell 22)
     # Link new selection head 22 into the list of selections (21 <-> 22)
@@ -146,9 +119,8 @@ subtest 'get_selection' => sub {
 };
 
 subtest 'get_which_selection' => sub {
-    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+    %$test_slice = Zigzag::initial_geometry();
 
-    # --- Setup for get_active_selection, get_selection, get_which_selection (using $test_slice) ---
     my $SELECT_HOME = 21; # From Zigzag.pm constants (already in initial_geometry)
 
     # Define new cells for selections
@@ -179,9 +151,8 @@ subtest 'get_which_selection' => sub {
 };
 
 subtest 'get_lastcell' => sub {
-    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+    %$test_slice = Zigzag::initial_geometry();
 
-    # --- Setup for get_lastcell tests (now using $test_slice) ---
     # Linear chain: 500 <-> 501 <-> 502 in d.testchain
     $test_slice->{'500'} = 'Cell 500 (start of linear chain)';
     $test_slice->{'501'} = 'Cell 501 (middle of linear chain)';
@@ -207,9 +178,8 @@ subtest 'get_lastcell' => sub {
 };
 
 subtest 'get_distance' => sub {
-    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+    %$test_slice = Zigzag::initial_geometry();
 
-    # --- Setup for get_distance tests (now using $test_slice) ---
     $test_slice->{'700'} = 'Cell 700 for get_distance';
     $test_slice->{'701'} = 'Cell 701 for get_distance';
     $test_slice->{'702'} = 'Cell 702 for get_distance';
@@ -229,9 +199,8 @@ subtest 'get_distance' => sub {
 };
 
 subtest 'get_outline_parent' => sub {
-    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+    %$test_slice = Zigzag::initial_geometry();
 
-    # --- Setup for get_outline_parent tests (now using $test_slice) ---
     $test_slice->{'800'} = 'Cell 800 (child for outline parent)';
     $test_slice->{'801'} = 'Cell 801 (parent for outline parent)';
     $test_slice->{'802'} = 'Cell 802 (intermediate for 800-d.2)';
@@ -257,9 +226,8 @@ subtest 'get_outline_parent' => sub {
 };
 
 subtest 'get_cell_contents' => sub {
-    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+    %$test_slice = Zigzag::initial_geometry();
 
-    # --- Setup for get_cell_contents tests (now using $test_slice) ---
     $test_slice->{'850'} = 'Direct content for 850';
     $test_slice->{'851'} = 'Cell 851 (clone of 852)'; # This content is just a note
     $test_slice->{'852'} = 'Content from original cell 852';
@@ -279,9 +247,8 @@ subtest 'get_cell_contents' => sub {
 };
 
 subtest 'get_cursor' => sub {
-    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+    %$test_slice = Zigzag::initial_geometry();
 
-    # --- Setup for get_cursor tests (now using $test_slice) ---
     # initial_geometry provides cursor 0 (11) and cursor 1 (16)
     # $CURSOR_HOME (10) -> 11 (cursor 0) -> 16 (cursor 1)
     $test_slice->{'900'} = 'Test Cursor 2';
@@ -301,7 +268,7 @@ subtest 'get_cursor' => sub {
 };
 
 subtest 'get_dimension' => sub {
-    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+    %$test_slice = Zigzag::initial_geometry();
     plan tests => 7;
     my $cursor_cell_for_dim_test = Zigzag::get_cursor(0); # Should be 11
     # Expected dimensions based on initial_geometry for cursor 0 (cell 11):
@@ -322,9 +289,8 @@ subtest 'get_dimension' => sub {
 };
 
 subtest 'get_links_to' => sub {
-    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+    %$test_slice = Zigzag::initial_geometry();
 
-    # --- Setup for get_links_to tests (now using $test_slice) ---
     # Define target and source cells
     $test_slice->{'950'} = 'Target cell for links';
     $test_slice->{'951'} = 'Source cell 1';
@@ -346,7 +312,6 @@ subtest 'get_links_to' => sub {
 };
 
 subtest 'wordbreak' => sub {
-    %$test_slice = Zigzag::initial_geometry(); # Initialize it
     plan tests => 4;
     is( Zigzag::wordbreak("short string", 20), "short string", "string shorter than limit");
     is( Zigzag::wordbreak("long string with spaces", 10), "long", "breaks at space before limit");
@@ -355,7 +320,6 @@ subtest 'wordbreak' => sub {
 };
 
 subtest 'dimension_is_essential' => sub {
-    %$test_slice = Zigzag::initial_geometry(); # Initialize it
     plan tests => 10;
     ok( Zigzag::dimension_is_essential('d.1'), "d.1 is essential");
     ok( Zigzag::dimension_is_essential('+d.2'), "+d.2 is essential");
@@ -371,7 +335,7 @@ subtest 'dimension_is_essential' => sub {
 
 # --- Tests for cell_new ---
 subtest 'cell_new' => sub {
-    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+    %$test_slice = Zigzag::initial_geometry();
     plan tests => 14;
 
     # Test Case 1: Create a new cell with default content.
@@ -401,10 +365,6 @@ subtest 'cell_new' => sub {
     my $recyclable_cell_id = '3010'; # Arbitrary high number for recycle test
     $test_slice->{$recyclable_cell_id} = "Recyclable";
 
-    # Save original DELETE_HOME links to restore later, as initial_geometry sets them up.
-    my $orig_dh_minus_d2 = $test_slice->{"${DELETE_HOME}-d.2"};
-    my $orig_dh_plus_d2 = $test_slice->{"${DELETE_HOME}+d.2"};
-
     # Put $recyclable_cell_id onto the recycle pile (making it the only item)
     $test_slice->{"${DELETE_HOME}-d.2"} = $recyclable_cell_id; # DELETE_HOME points to it
     $test_slice->{"${recyclable_cell_id}+d.2"} = $DELETE_HOME; # It points back to DELETE_HOME
@@ -418,26 +378,11 @@ subtest 'cell_new' => sub {
     is($test_slice->{"${DELETE_HOME}-d.2"}, $DELETE_HOME, "4.3: DELETE_HOME -d.2 link updated (points to self as pile is empty)");
     is($test_slice->{"${recycled_cell_id_actual}+d.2"}, undef, "4.4: Recycled cell's +d.2 link is removed");
     is($test_slice->{"${recycled_cell_id_actual}-d.2"}, undef, "4.5: Recycled cell's -d.2 link is removed");
-
-    # Cleanup for recycle test:
-    # Restore DELETE_HOME's original d.2 links
-    $test_slice->{"${DELETE_HOME}-d.2"} = $orig_dh_minus_d2;
-    $test_slice->{"${DELETE_HOME}+d.2"} = $orig_dh_plus_d2;
-    # Delete the test cells created if they weren't recycled, or if their content needs resetting
-    delete $test_slice->{$new_cell_id_default}; # Content was its own ID
-    delete $test_slice->{$new_cell_id_content};
-    delete $test_slice->{$cell_id1_multi};
-    delete $test_slice->{$cell_id2_multi};
-    # $recyclable_cell_id ('3010') was reused, its content changed, and links cleared.
-    # We can delete it or leave it with its new content for this test scope.
-    # For strictness, delete it if no other test expects it.
-    delete $test_slice->{$recyclable_cell_id};
-    # Note: 'n' is no longer manually restored. Each subtest gets a fresh 'n' via initial_geometry().
 };
 
 # --- Tests for cell_excise ---
 subtest 'cell_excise' => sub {
-    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+    %$test_slice = Zigzag::initial_geometry();
     plan tests => 17;
 
     my $dim = 'd.testex'; # Common dimension for most tests
@@ -509,7 +454,7 @@ subtest 'cell_excise' => sub {
 
 # --- Setup for link_make tests ---
 subtest 'link_make' => sub {
-    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+    %$test_slice = Zigzag::initial_geometry();
     plan tests => 7; # 2 for success, 5 for die cases
 
     # Test 1: Successful link
@@ -538,10 +483,6 @@ subtest 'link_make' => sub {
     eval { Zigzag::link_make('1000', '1003', '+d.testlink'); }; # 1000 already has +d.testlink to 1001
     like($@, qr/1000 already linked/, "link_make: die when cell1 already linked");
 
-    # Cleanup link from Test 1 for Test 6 clarity - though new dim used in test 6
-    delete $test_slice->{'1000+d.testlink'};
-    delete $test_slice->{'1001-d.testlink'};
-
     # Test 6: Error case: $cell2 already linked in reverse_sign($dir)
     # Per problem: Link '1002' ('X') and '1003' ('B') with '+d.testlink' ('+D').
     # This creates B-D = X. ('1003-d.testlink' = '1002')
@@ -558,7 +499,7 @@ subtest 'link_make' => sub {
 
 # --- Setup for link_break tests ---
 subtest 'link_break' => sub {
-    %$test_slice = Zigzag::initial_geometry(); # Initialize it
+    %$test_slice = Zigzag::initial_geometry();
     plan tests => 12; # 2x2 for success cases, 8 for die cases
 
     # Setup cells for link_break tests
@@ -624,30 +565,4 @@ subtest 'link_break' => sub {
     # Test 10: Error case (2 args): $cell1 has no link in $dir
     eval { Zigzag::link_break('2008', '+d.testbreak_e7'); }; # 2008 is not linked
     like($@, qr/2008 has no link in direction \+d.testbreak_e7/, "link_break(2 args): die when cell1 has no link in dir");
-
-    # Cleanup
-    my @cleanup_dims = (
-        '+d.testbreak_s3', '-d.testbreak_s3', '+d.testbreak_s2', '-d.testbreak_s2',
-        '+d.testbreak_e1', '-d.testbreak_e1', '+d.testbreak_e2', '-d.testbreak_e2',
-        '+d.testbreak_e3', '-d.testbreak_e3', '+d.testbreak_e4', '-d.testbreak_e4',
-        '+d.testbreak_e5', '-d.testbreak_e5', '+d.testbreak_e6', '-d.testbreak_e6',
-        '+d.testbreak_e7', '-d.testbreak_e7'
-    );
-    foreach my $i (0..8) {
-        my $cell_id_num = 2000 + $i;
-        # For cells that might not exist during a test (nonexistent_lb*), skip delete if not in test_slice
-        my $cell_id = $test_slice->{$cell_id_num} ? $cell_id_num : undef; 
-        if (defined $cell_id) {
-            delete $test_slice->{$cell_id};
-            foreach my $dim (@cleanup_dims) {
-                delete $test_slice->{"${cell_id}${dim}"};
-            }
-        }
-    }
-     # Explicitly delete links that might involve non-existent cells if created temporarily by link_make
-    foreach my $cell_id_str ('nonexistent_lb1', 'nonexistent_lb2', 'nonexistent_lb3') {
-        foreach my $dim (@cleanup_dims) {
-            delete $test_slice->{"${cell_id_str}${dim}"};
-        }
-    }
 };


### PR DESCRIPTION
This commit adds new test suites for several functions in Zigzag.pm:
    - link_make and link_break: Covering successful operations and various error conditions.
    - cell_new: Testing default content, specified content, unique ID generation, and cell recycling.
    - cell_excise: Testing excision from various list structures.

As a result of the new tests, ensured that cell_new returns the new cell ID as expected rather than the new content